### PR TITLE
Bind `yas-expand` to `M-<SPC>` since that correctly expands snippets.

### DIFF
--- a/config.org
+++ b/config.org
@@ -1180,6 +1180,7 @@ snippets. Binds ~M-m y s~ to show a table of active snippets.
   (use-package yasnippet
     :ensure t
     :diminish (yas-minor-mode "Y")
+    :bind ("M-<SPC>" . yas-expand)
     :config
     (yas-reload-all))
   (use-package yasnippet-snippets


### PR DESCRIPTION
Diminish downside of changes in #8 